### PR TITLE
Remove name mangling which prevents subclassing OAuthClient.

### DIFF
--- a/smartfile/__init__.py
+++ b/smartfile/__init__.py
@@ -267,7 +267,7 @@ try:
             r = requests.post(urlparse.urljoin(self.url, 'oauth/access_token/'), auth=oauth)
             credentials = urlparse.parse_qs(r.text)
             self._access = OAuthToken(credentials.get('oauth_token')[0],
-                                       credentials.get('oauth_token_secret')[0])
+                                      credentials.get('oauth_token_secret')[0])
             return self._access
 
 


### PR DESCRIPTION
I tried to subclass `OAuthClient` for a project\* but found that the name-mangled instance attributes `__access` and `__client` made just rewriting from scratch easier. I've only been working with your guys' library for a day so I apologize if there's a specific reason for the dunder prefix, but inheritance is close to broken in this case.

\* _I wanted to get just the response object from `_do_request` so I could process HTTP requests based on their response code & body instead of catching exceptions thrown by `OAuthClient`_
