### PR TITLE
Use requirements.txt dependencies for setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
 before_install:
   - sudo apt-get install librsync1 -qq
 install:
-  - pip install --timeout=30 pep8 --use-mirrors
-  - pip install --timeout=30 pyflakes --use-mirrors
-  - pip install --timeout=30 -r requirements.txt --use-mirrors
-  - pip install --timeout=30 -q -e . --use-mirrors
+  - pip install --timeout=30 pep8
+  - pip install --timeout=30 pyflakes
+  - pip install --timeout=30 -r requirements.txt
+  - pip install --timeout=30 -q -e .
 before_script:
   - make verify
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include requirements.txt
 include README.rst

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ from setuptools import setup
 VERSION_PATTERN = re.compile(r'^[^#]*__version__\W*\=\W*["\'](.*)["\']')
 VERSION = None
 
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+required = [r for r in required if not r.startswith('git')]
+
 
 def get_path(path):
     return os.path.join(os.path.dirname(__file__), path)
@@ -35,11 +40,7 @@ setup(
     version=versrel,
     description='A Python client for the SmartFile API.',
     long_description=long_description,
-    install_requires=[
-        'oauthlib',
-        'requests',
-        'requests_oauthlib',
-    ],
+    install_requires=required,
     author='SmartFile',
     author_email='tech@smartfile.com',
     maintainer='Ben Timby',


### PR DESCRIPTION
The dependencies had gotten out of date in `setup.py`. This will make it so that it is always in sync with `requirements.txt`.