### PR TITLE
Fix CI testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,30 @@
+.PHONY: test
 test:
 	coverage run tests.py
 
+.PHONY: verify
 verify:
 	pyflakes smartfile
 	pep8 --ignore=E501,E225 smartfile
 
+.PHONY: install
 install:
 	python setup.py install
 
+.PHONY: publish
 publish:
 	python setup.py register
 	python setup.py sdist upload
 
+.PHONY: profile
 profile:
 	python profile.py
 
+.PHONY: clean
 clean:
 	find . -name *.pyc -delete
 
+.PHONY: distclean
 distclean: clean
 	rm -rf env
 

--- a/tests.py
+++ b/tests.py
@@ -303,8 +303,8 @@ class BasicClientTestCase(DownloadTestCase, UploadTestCase, MethodTestCase,
                     address, port = address
                 else:
                     port = self.server.server_port
-                netrc = b"machine 127.0.0.1:%s\n  login %s\n  password %s" % (
-                        port, API_KEY, API_PASSWORD)
+                netrc = b"machine 127.0.0.1:%i\n  login %s\n  password %s" % (
+                        port, API_KEY.encode(), API_PASSWORD.encode())
                 os.write(fd, netrc)
             finally:
                 os.close(fd)
@@ -359,7 +359,7 @@ class HTTPJSONRequestHandler(TestHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(b"%s" % (json.dumps({'foo': 'bar'}), ))
+        self.wfile.write(b"%s" % (json.dumps({'foo': 'bar'}).encode(), ))
 
 
 class JSONTestCase(object):

--- a/tests.py
+++ b/tests.py
@@ -303,9 +303,9 @@ class BasicClientTestCase(DownloadTestCase, UploadTestCase, MethodTestCase,
                     address, port = address
                 else:
                     port = self.server.server_port
-                netrc = b"machine 127.0.0.1:%i\n  login %s\n  password %s" % (
-                        port, API_KEY.encode('utf8'),
-                        API_PASSWORD.encode('utf8'))
+                netrc = 'machine 127.0.0.1:%i\n  login %s\n  password %s' % (
+                        port, API_KEY, API_PASSWORD)
+                netrc = netrc.encode('utf8')
                 os.write(fd, netrc)
             finally:
                 os.close(fd)

--- a/tests.py
+++ b/tests.py
@@ -304,7 +304,8 @@ class BasicClientTestCase(DownloadTestCase, UploadTestCase, MethodTestCase,
                 else:
                     port = self.server.server_port
                 netrc = b"machine 127.0.0.1:%i\n  login %s\n  password %s" % (
-                        port, API_KEY.encode(), API_PASSWORD.encode())
+                        port, API_KEY.encode('utf8'),
+                        API_PASSWORD.encode('utf8'))
                 os.write(fd, netrc)
             finally:
                 os.close(fd)
@@ -359,7 +360,7 @@ class HTTPJSONRequestHandler(TestHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(b"%s" % (json.dumps({'foo': 'bar'}).encode(), ))
+        self.wfile.write(json.dumps({'foo': 'bar'}).encode('utf8'))
 
 
 class JSONTestCase(object):


### PR DESCRIPTION
Previously, the tests weren't even being run. This is because a directory named `test` was added and the Makefile target `test` was not `PHONY`. Once the tests were being run, there was an incompatibility with the string encoding that needed to be resolved for tests to pass.