### PR TITLE
Use correct byte count function

### DIFF
--- a/test/test_smartfile.py
+++ b/test/test_smartfile.py
@@ -44,7 +44,7 @@ class CustomOperationsTestCase(unittest.TestCase):
         f = StringIO(file_contents)
         f.seek(0)
         self.api.upload(TESTFN, f)
-        self.assertEquals(self.get_data()['size'], f.len)
+        self.assertEquals(self.get_data()['size'], f.tell())
 
     def download(self):
         self.api.download(TESTFN)


### PR DESCRIPTION
`len` does not exist in python 3 `StringIO`.